### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,4 +1,7 @@
 name: Enable Auto-Merge for Dependabot PRs
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/step2dev/lazy-ui-docs/security/code-scanning/1](https://github.com/step2dev/lazy-ui-docs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow enables auto-merge for Dependabot PRs, it only needs `contents: read` and `pull-requests: write` permissions. These permissions allow the workflow to read repository contents and modify pull requests, which are necessary for enabling auto-merge.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
